### PR TITLE
Fix scan result parsing

### DIFF
--- a/app.py
+++ b/app.py
@@ -115,28 +115,22 @@ def run_scan(scan_id, device_id, tuner_index):
             }
 
         elif line.startswith("LOCK:") and current_group is not None:
-            parts = line.split()
-            lock_part = next((p for p in parts if p.startswith("lock=")), None)
-            if lock_part:
-                locked_val = lock_part.split("=", 1)[1]
-                current_group["lock"] = (
-                    locked_val if locked_val.lower() != "none" else None
-                )
-                capturing = locked_val.lower() != "none"
-
-            ss_part = next((p for p in parts if p.startswith("ss=")), None)
-            if ss_part:
-                try:
-                    current_group["ss"] = int(ss_part.split("=", 1)[1])
-                except ValueError:
-                    current_group["ss"] = 0
-
-            snq_part = next((p for p in parts if p.startswith("snq=")), None)
-            if snq_part:
-                try:
-                    current_group["snq"] = int(snq_part.split("=", 1)[1])
-                except ValueError:
-                    current_group["snq"] = 0
+            # Example: "LOCK: 8vsb (ss=85 snq=88 seq=100)" or "LOCK: none (ss=0 snq=0 seq=0)"
+            m = re.search(r"LOCK:\s+(\S+)(?:\s+\(ss=(\d+)\s+snq=(\d+)\s+seq=(\d+)\))?", line)
+            if m:
+                lock_val, ss_val, snq_val, _ = m.groups()
+                current_group["lock"] = lock_val if lock_val.lower() != "none" else None
+                capturing = lock_val.lower() != "none"
+                if ss_val is not None:
+                    try:
+                        current_group["ss"] = int(ss_val)
+                    except ValueError:
+                        current_group["ss"] = 0
+                if snq_val is not None:
+                    try:
+                        current_group["snq"] = int(snq_val)
+                    except ValueError:
+                        current_group["snq"] = 0
 
         elif line.startswith("PROGRAM") and capturing and current_group is not None:
             after_colon = line.split(":", 1)[1].strip()
@@ -393,28 +387,22 @@ def scan_channels():
             }
 
         elif line.startswith("LOCK:") and current_group is not None:
-            parts = line.split()
-            lock_part = next((p for p in parts if p.startswith("lock=")), None)
-            if lock_part:
-                locked_val = lock_part.split("=", 1)[1]
-                current_group["lock"] = (
-                    locked_val if locked_val.lower() != "none" else None
-                )
-                capturing = locked_val.lower() != "none"
-
-            ss_part = next((p for p in parts if p.startswith("ss=")), None)
-            if ss_part:
-                try:
-                    current_group["ss"] = int(ss_part.split("=", 1)[1])
-                except ValueError:
-                    current_group["ss"] = 0
-
-            snq_part = next((p for p in parts if p.startswith("snq=")), None)
-            if snq_part:
-                try:
-                    current_group["snq"] = int(snq_part.split("=", 1)[1])
-                except ValueError:
-                    current_group["snq"] = 0
+            # Example: "LOCK: qam256 (ss=80 snq=90 seq=100)" or "LOCK: none (ss=0 snq=0 seq=0)"
+            m = re.search(r"LOCK:\s+(\S+)(?:\s+\(ss=(\d+)\s+snq=(\d+)\s+seq=(\d+)\))?", line)
+            if m:
+                lock_val, ss_val, snq_val, _ = m.groups()
+                current_group["lock"] = lock_val if lock_val.lower() != "none" else None
+                capturing = lock_val.lower() != "none"
+                if ss_val is not None:
+                    try:
+                        current_group["ss"] = int(ss_val)
+                    except ValueError:
+                        current_group["ss"] = 0
+                if snq_val is not None:
+                    try:
+                        current_group["snq"] = int(snq_val)
+                    except ValueError:
+                        current_group["snq"] = 0
 
         elif line.startswith("PROGRAM") and capturing and current_group is not None:
             after_colon = line.split(":", 1)[1].strip()

--- a/app.py
+++ b/app.py
@@ -5,34 +5,62 @@ import threading
 import uuid
 from flask import Flask, jsonify, request, send_from_directory
 
-app = Flask(
-    __name__,
-    static_folder=".",
-    static_url_path=""
-)
+app = Flask(__name__, static_folder=".", static_url_path="")
 
 # Store scan progress keyed by UUID
 scans = {}
 
 # Mapping from frequency (Hz) to physical channel
 FREQ_TO_CHANNEL = {
-    57000000: 2,   63000000: 3,   69000000: 4,
-    79000000: 5,   85000000: 6,  177000000: 7,
-   183000000: 8,  189000000: 9,  195000000: 10,
-   201000000: 11, 207000000: 12, 213000000: 13,
-   473000000: 14, 479000000: 15, 485000000: 16,
-   491000000: 17, 497000000: 18, 503000000: 19,
-   509000000: 20, 515000000: 21, 521000000: 22,
-   527000000: 23, 533000000: 24, 539000000: 25,
-   545000000: 26, 551000000: 27, 557000000: 28,
-   563000000: 29, 569000000: 30, 575000000: 31,
-   581000000: 32, 587000000: 33, 593000000: 34,
-   599000000: 35, 605000000: 36, 617000000: 38,
-   623000000: 39, 629000000: 40, 635000000: 41,
-   641000000: 42, 647000000: 43, 653000000: 44,
-   659000000: 45, 665000000: 46, 671000000: 47,
-   677000000: 48, 683000000: 49, 689000000: 50,
-    695000000: 51
+    57000000: 2,
+    63000000: 3,
+    69000000: 4,
+    79000000: 5,
+    85000000: 6,
+    177000000: 7,
+    183000000: 8,
+    189000000: 9,
+    195000000: 10,
+    201000000: 11,
+    207000000: 12,
+    213000000: 13,
+    473000000: 14,
+    479000000: 15,
+    485000000: 16,
+    491000000: 17,
+    497000000: 18,
+    503000000: 19,
+    509000000: 20,
+    515000000: 21,
+    521000000: 22,
+    527000000: 23,
+    533000000: 24,
+    539000000: 25,
+    545000000: 26,
+    551000000: 27,
+    557000000: 28,
+    563000000: 29,
+    569000000: 30,
+    575000000: 31,
+    581000000: 32,
+    587000000: 33,
+    593000000: 34,
+    599000000: 35,
+    605000000: 36,
+    617000000: 38,
+    623000000: 39,
+    629000000: 40,
+    635000000: 41,
+    641000000: 42,
+    647000000: 43,
+    653000000: 44,
+    659000000: 45,
+    665000000: 46,
+    671000000: 47,
+    677000000: 48,
+    683000000: 49,
+    689000000: 50,
+    695000000: 51,
 }
 
 
@@ -50,7 +78,7 @@ def run_scan(scan_id, device_id, tuner_index):
         scans[scan_id] = {"finished": True, "results": []}
         return
 
-    results = []
+    results: list[dict] = []
     current_group = None
     capturing = False
 
@@ -58,14 +86,25 @@ def run_scan(scan_id, device_id, tuner_index):
         line = raw.strip()
 
         if line.startswith("SCANNING:"):
-            if current_group and current_group.get("subchannels"):
+            if current_group is not None and (
+                current_group.get("lock") is not None
+                or current_group.get("subchannels")
+            ):
                 results.append(current_group)
                 scans[scan_id]["results"] = list(results)
             capturing = False
 
             parts = line.split()
-            m = re.search(r"\((\d+)\)", " ".join(parts[2:]))
+            freq = None
+            try:
+                freq = int(parts[1])
+            except (IndexError, ValueError):
+                pass
+
+            m = re.search(r"\((?:us-bcast:)?(\d+)\)", line)
             phys = int(m.group(1)) if m else None
+            if phys is None and freq is not None:
+                phys = FREQ_TO_CHANNEL.get(freq)
 
             current_group = {
                 "physical": phys,
@@ -84,12 +123,14 @@ def run_scan(scan_id, device_id, tuner_index):
                     locked_val if locked_val.lower() != "none" else None
                 )
                 capturing = locked_val.lower() != "none"
+
             ss_part = next((p for p in parts if p.startswith("ss=")), None)
             if ss_part:
                 try:
                     current_group["ss"] = int(ss_part.split("=", 1)[1])
                 except ValueError:
                     current_group["ss"] = 0
+
             snq_part = next((p for p in parts if p.startswith("snq=")), None)
             if snq_part:
                 try:
@@ -99,19 +140,22 @@ def run_scan(scan_id, device_id, tuner_index):
 
         elif line.startswith("PROGRAM") and capturing and current_group is not None:
             after_colon = line.split(":", 1)[1].strip()
-            for m in re.finditer(r"(\d+\.\d+)\s+([A-Za-z0-9\-\s&/]+?)(?=\s+\d+\.\d+|$)", after_colon):
+            for m in re.finditer(r"(\d+\.\d+)\s+(.+?)(?=\s+\d+\.\d+|$)", after_colon):
                 num = m.group(1).strip()
                 name = m.group(2).strip()
                 current_group["subchannels"].append({"num": num, "name": name})
-                scans[scan_id]["results"] = list(results) + [current_group]
+            scans[scan_id]["results"] = list(results) + [current_group]
 
     proc.wait()
 
-    if current_group and current_group.get("subchannels"):
+    if current_group is not None and (
+        current_group.get("lock") is not None or current_group.get("subchannels")
+    ):
         results.append(current_group)
 
     scans[scan_id]["results"] = results
     scans[scan_id]["finished"] = True
+
 
 def discover_device():
     """
@@ -120,8 +164,7 @@ def discover_device():
     """
     try:
         out = subprocess.check_output(
-            ["hdhomerun_config", "discover"],
-            stderr=subprocess.DEVNULL
+            ["hdhomerun_config", "discover"], stderr=subprocess.DEVNULL
         ).decode()
     except subprocess.CalledProcessError:
         return None, None
@@ -134,9 +177,11 @@ def discover_device():
 
     return None, None
 
+
 @app.route("/")
 def index():
     return send_from_directory(".", "index.html")
+
 
 @app.route("/api/status")
 def api_status():
@@ -145,37 +190,39 @@ def api_status():
     """
     device_id, _ = discover_device()
     if not device_id:
-        return jsonify({
-            "connected": False,
-            "device_id": None,
-            "device_ip": None,
-            "tuner_count": None
-        }), 503
+        return (
+            jsonify(
+                {"connected": False, "device_id": None, "device_ip": None, "tuner_count": None}
+            ),
+            503,
+        )
 
     # Verify the device is reachable by querying sys/version
     try:
         subprocess.check_output(
-            ["hdhomerun_config", device_id, "get", "/sys/version"],
-            stderr=subprocess.DEVNULL
+            ["hdhomerun_config", device_id, "get", "/sys/version"], stderr=subprocess.DEVNULL
         )
         # Fetch local IP to display
         ip_output = subprocess.getoutput("hostname -I").split()
         device_ip = ip_output[0] if ip_output else "unknown"
         # Assume 4 tuners (adjust if necessary)
         tuner_count = 4
-        return jsonify({
-            "connected": True,
-            "device_id": device_id,
-            "device_ip": device_ip,
-            "tuner_count": tuner_count
-        })
+        return jsonify(
+            {
+                "connected": True,
+                "device_id": device_id,
+                "device_ip": device_ip,
+                "tuner_count": tuner_count,
+            }
+        )
     except subprocess.CalledProcessError:
-        return jsonify({
-            "connected": False,
-            "device_id": None,
-            "device_ip": None,
-            "tuner_count": None
-        }), 503
+        return (
+            jsonify(
+                {"connected": False, "device_id": None, "device_ip": None, "tuner_count": None}
+            ),
+            503,
+        )
+
 
 @app.route("/api/tuners")
 def api_tuners():
@@ -226,7 +273,7 @@ def api_tuners():
                     except IndexError:
                         raw_ch_value = None
 
-        locked = (lockkey.lower() != "none")
+        locked = lockkey.lower() != "none"
 
         # Determine physical channel
         channel = None
@@ -245,15 +292,17 @@ def api_tuners():
                     except ValueError:
                         channel = None
 
-        tuners.append({
-            "index": idx,
-            "locked": locked,
-            "lock": lockkey,
-            "channel": channel,
-            "ss": ss,
-            "snq": snq,
-            "seq": seq
-        })
+        tuners.append(
+            {
+                "index": idx,
+                "locked": locked,
+                "lock": lockkey,
+                "channel": channel,
+                "ss": ss,
+                "snq": snq,
+                "seq": seq,
+            }
+        )
 
     return jsonify(tuners)
 
@@ -284,6 +333,7 @@ def api_scan_status(scan_id):
         return jsonify({"error": "Invalid scan id"}), 404
     return jsonify({"finished": data["finished"], "results": data["results"]})
 
+
 @app.route("/api/scan", methods=["POST"])
 def scan_channels():
     """
@@ -300,13 +350,15 @@ def scan_channels():
 
     cmd = ["hdhomerun_config", device_id, "scan", f"/tuner{tuner_index}"]
     try:
-        proc = subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        proc = subprocess.run(
+            cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+        )
         lines = proc.stdout.splitlines()
     except subprocess.CalledProcessError as e:
         # Include scan log in error message
         return jsonify({"status": "error", "message": f"Scan failed: {e.stdout.strip()}"}), 500
 
-    results = []
+    results: list[dict] = []
     current_group = None
     capturing = False
 
@@ -314,23 +366,30 @@ def scan_channels():
         line = raw.strip()
 
         if line.startswith("SCANNING:"):
-            if current_group and current_group.get("subchannels"):
+            if current_group is not None and (
+                current_group.get("lock") is not None or current_group.get("subchannels")
+            ):
                 results.append(current_group)
             capturing = False
 
             parts = line.split()
-            # parts: ["SCANNING:", "<frequency>", "(<physical>)"]
-            # e.g. "SCANNING: 605000000 (36)"
-            freq_hz = parts[1]
-            m = re.search(r"\((\d+)\)", " ".join(parts[2:]))
+            freq = None
+            try:
+                freq = int(parts[1])
+            except (IndexError, ValueError):
+                pass
+
+            m = re.search(r"\((?:us-bcast:)?(\d+)\)", line)
             phys = int(m.group(1)) if m else None
+            if phys is None and freq is not None:
+                phys = FREQ_TO_CHANNEL.get(freq)
 
             current_group = {
                 "physical": phys,
                 "lock": None,
                 "ss": 0,
                 "snq": 0,
-                "subchannels": []
+                "subchannels": [],
             }
 
         elif line.startswith("LOCK:") and current_group is not None:
@@ -338,27 +397,39 @@ def scan_channels():
             lock_part = next((p for p in parts if p.startswith("lock=")), None)
             if lock_part:
                 locked_val = lock_part.split("=", 1)[1]
-                current_group["lock"] = locked_val if locked_val.lower() != "none" else None
-                capturing = (locked_val.lower() != "none")
+                current_group["lock"] = (
+                    locked_val if locked_val.lower() != "none" else None
+                )
+                capturing = locked_val.lower() != "none"
+
             ss_part = next((p for p in parts if p.startswith("ss=")), None)
             if ss_part:
-                current_group["ss"] = int(ss_part.split("=", 1)[1])
+                try:
+                    current_group["ss"] = int(ss_part.split("=", 1)[1])
+                except ValueError:
+                    current_group["ss"] = 0
+
             snq_part = next((p for p in parts if p.startswith("snq=")), None)
             if snq_part:
-                current_group["snq"] = int(snq_part.split("=", 1)[1])
+                try:
+                    current_group["snq"] = int(snq_part.split("=", 1)[1])
+                except ValueError:
+                    current_group["snq"] = 0
 
         elif line.startswith("PROGRAM") and capturing and current_group is not None:
             after_colon = line.split(":", 1)[1].strip()
-            # Regex to find "8.1 WAGM-HD", "8.2 WAGMFOX", etc.
-            for m in re.finditer(r"(\d+\.\d+)\s+([A-Za-z0-9\-\s&/]+?)(?=\s+\d+\.\d+|$)", after_colon):
+            for m in re.finditer(r"(\d+\.\d+)\s+(.+?)(?=\s+\d+\.\d+|$)", after_colon):
                 num = m.group(1).strip()
                 name = m.group(2).strip()
                 current_group["subchannels"].append({"num": num, "name": name})
 
-    if current_group and current_group.get("subchannels"):
+    if current_group is not None and (
+        current_group.get("lock") is not None or current_group.get("subchannels")
+    ):
         results.append(current_group)
 
     return jsonify({"status": "success", "results": results})
+
 
 @app.route("/api/tune", methods=["POST"])
 def api_tune():
@@ -384,7 +455,9 @@ def api_tune():
     time.sleep(1)  # allow PSIP to populate
 
     # 3) Fetch streaminfo for subchannels
-    streaminfo_raw = subprocess.getoutput(f"hdhomerun_config {device_id} get /tuner{tuner}/streaminfo")
+    streaminfo_raw = subprocess.getoutput(
+        f"hdhomerun_config {device_id} get /tuner{tuner}/streaminfo"
+    )
     subchannels = []
     for line in streaminfo_raw.strip().splitlines():
         parts = line.split()
@@ -398,6 +471,7 @@ def api_tune():
             subchannels.append({"num": num, "name": name})
 
     return jsonify({"subchannels": subchannels})
+
 
 @app.route("/api/program_info", methods=["POST"])
 def api_program_info():
@@ -414,7 +488,9 @@ def api_program_info():
     if not device_id or tuner is None or not program:
         return jsonify({"bitrate": None, "max_bitrate": None}), 400
 
-    streaminfo_raw = subprocess.getoutput(f"hdhomerun_config {device_id} get /tuner{tuner}/streaminfo")
+    streaminfo_raw = subprocess.getoutput(
+        f"hdhomerun_config {device_id} get /tuner{tuner}/streaminfo"
+    )
     bitrate = None
     max_bitrate = None
 
@@ -441,6 +517,7 @@ def api_program_info():
 
     return jsonify({"bitrate": bitrate, "max_bitrate": max_bitrate})
 
+
 @app.route("/api/clear_locks", methods=["POST"])
 def api_clear_locks():
     """
@@ -456,6 +533,7 @@ def api_clear_locks():
         raw = subprocess.getoutput(f"hdhomerun_config {device_id} set /tuner{idx}/lockkey none")
         results.append({"tuner": idx, "raw": raw})
     return jsonify({"results": results})
+
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=5070)


### PR DESCRIPTION
## Summary
- improve scan result parsing
- capture channels only when locked
- robustly detect physical channel from SCANNING lines

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6847899ad2f48320902e6379ea8daacb