### PR TITLE
Improve dependency instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ A web-based manual tuner interface for SiliconDust HDHomeRun devices. The applic
    pip install -r requirements.txt
    ```
 
+   If you encounter `ModuleNotFoundError: No module named 'flask'`,
+   ensure the above commands completed successfully and that your
+   virtual environment is activated.
+
 2. Ensure `hdhomerun_config` is installed on your system. On Debian-based systems:
 
    ```bash

--- a/app.py
+++ b/app.py
@@ -3,7 +3,14 @@ import subprocess
 import re
 import threading
 import uuid
-from flask import Flask, jsonify, request, send_from_directory
+
+try:
+    from flask import Flask, jsonify, request, send_from_directory
+except ImportError as exc:  # pragma: no cover - runtime guard only
+    raise ImportError(
+        "Flask is required to run this application."
+        " Please install dependencies with 'pip install -r requirements.txt'."
+    ) from exc
 
 app = Flask(__name__, static_folder=".", static_url_path="")
 


### PR DESCRIPTION
## Summary
- explain missing flask error in the README
- guard Flask import with a helpful message

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68478e9eab808320a9e3e3082e664a80