### PR TITLE
Use clear_locks endpoint for force-clear button

### DIFF
--- a/index.html
+++ b/index.html
@@ -772,24 +772,12 @@
     }
 
     // ───────────────────────────────────────────────────────────
-    // 5) Force‐clear all tuner locks (calls /api/override?tuner=<n> for each tuner 0..3)
+    // 5) Force‐clear all tuner locks (POST /api/clear_locks)
     // ───────────────────────────────────────────────────────────
     document.getElementById("force-clear-btn").addEventListener("click", () => {
-      for (let tunerId = 0; tunerId < 4; tunerId++) {
-        fetch(`/api/override?tuner=${tunerId}`, {
-          method: "POST",
-        })
-          .then((r) => {
-            if (!r.ok) console.error(`Failed to clear tuner ${tunerId} lock`);
-            return r.json();
-          })
-          .then((resp) => {
-            // Optionally inspect resp.status or resp.message
-          })
-          .catch((err) => {
-            console.error(`Error unlocking tuner ${tunerId}:`, err);
-          });
-      }
+      fetch("/api/clear_locks", { method: "POST" }).catch((err) => {
+        console.error("Error clearing locks:", err);
+      });
     });
 
     // ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- update the force clear button to call `/api/clear_locks`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847c8bedb088320875bff419b827053