### PR TITLE
Update scan button state handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -382,6 +382,8 @@
     updateProgressBar("seq-progress-bar", "seq-percentage-text", null, () => {});
   }
 
+  let scanHasRun = false;
+
   // Toggle the "Scan Again" button into a spinner state
   function setScanning(isScanning) {
     const btn = document.getElementById("scan-again-btn");
@@ -395,12 +397,13 @@
       `;
     } else {
       btn.disabled = false;
-      btn.innerHTML = "Scan Again";
+      btn.innerHTML = scanHasRun ? "Scan Again" : "Scan for Channels";
     }
   }
 
   document.addEventListener("DOMContentLoaded", () => {
     let selectedTuner = null;
+    setScanning(false);
 
     // ───────────────────────────────────────────────────────────
     // Chart.js (time‐series, not streaming plugin)
@@ -679,6 +682,7 @@
                 }
                 if (resp.finished) {
                   clearInterval(poll);
+                  scanHasRun = true;
                   setScanning(false);
                 }
               })


### PR DESCRIPTION
## Summary
- track if a scan has been run yet
- adjust `setScanning` to show either **Scan for Channels** or **Scan Again**
- initialise scan button state on page load
- mark scan completion when `/api/scan/start` finishes polling

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6847c8bbc3b083209e2a246a9249d493