### PR TITLE
Fix Docker build to include app-script.js

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,10 @@ WORKDIR /app
 COPY requirements.txt /app/
 RUN pip install --no-cache-dir -r requirements.txt
 
-# 5) Copy application code (app.py + static folder) into /app
+# 5) Copy application code (app.py + static files) into /app
 COPY app.py /app/
 COPY index.html /app/
+COPY app-script.js /app/
 
 # 6) Expose port 5070
 EXPOSE 5070


### PR DESCRIPTION
## Summary
- include `app-script.js` in Docker image so the frontend works

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6847d152a8048320b36bf8e8820ba831