### PR TITLE
Fix JS script path and undo compose changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -287,6 +287,6 @@
     ></script>
     <!-- Apache ECharts for realtime charts -->
     <script src="https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js"></script>
-<script src ="app-script.js"></script>
+<script src="app-script.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- revert Docker Compose image build step
- clarify Docker Compose instructions to pull the image
- correct `app-script.js` path in HTML

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`
- `python app.py >/tmp/flask.log 2>&1 &` *(fails: Address already in use)*

------
https://chatgpt.com/codex/tasks/task_e_6847d4c2ea548320a6e9cc99d54e3a44