### PR TITLE
Use gunicorn for production server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,5 @@ COPY app-script.js /app/
 # 6) Expose port 5070
 EXPOSE 5070
 
-# 7) Run the Flask app using the venv's python
-CMD ["python", "app.py"]
+# 7) Run the Flask app with Gunicorn
+CMD ["gunicorn", "--bind", "0.0.0.0:5070", "app:app"]

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Ongoing maintenance and improvements are handled primarily through ChatGPT.
    sudo apt-get install hdhomerun-config
    ```
 
-3. Run the application:
+3. Run the application for local development:
 
    ```bash
    python app.py
@@ -43,12 +43,18 @@ Ongoing maintenance and improvements are handled primarily through ChatGPT.
 
    The web UI will be available at <http://localhost:5070>.
 
+   For production, use Gunicorn:
+
+   ```bash
+   gunicorn --bind 0.0.0.0:5070 app:app
+   ```
+
 Apache ECharts is loaded via CDN in `index.html`, so no additional
 JavaScript build step is required.
 
 ## Docker Usage
 
-The repository contains a `Dockerfile` and `docker-compose.yml` for running the tuner in a container. The container exposes port `5070`.
+The repository contains a `Dockerfile` and `docker-compose.yml` for running the tuner in a container. The container exposes port `5070` and runs the app with Gunicorn.
 
 Build the image and run it with Docker:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Flask==2.3.3
+gunicorn==23.0.0


### PR DESCRIPTION
## Summary
- add gunicorn to requirements
- run gunicorn in Docker container
- document gunicorn usage for production

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6847dafa963c83209b67ef894b582421