### PR TITLE
Fix tuner lock clearing and chart polling

### DIFF
--- a/app.py
+++ b/app.py
@@ -529,7 +529,13 @@ def api_clear_locks():
 
     results = []
     for idx in range(4):
-        raw = subprocess.getoutput(f"hdhomerun_config {device_id} set /tuner{idx}/lockkey none")
+        # Stop any active stream on the tuner before releasing the lock
+        subprocess.getoutput(
+            f"hdhomerun_config {device_id} set /tuner{idx}/channel none"
+        )
+        raw = subprocess.getoutput(
+            f"hdhomerun_config {device_id} set /tuner{idx}/lockkey none"
+        )
         results.append({"tuner": idx, "raw": raw})
     return jsonify({"results": results})
 


### PR DESCRIPTION
## Summary
- ensure tuners are stopped before clearing lock keys
- allow pausing of polling for both tuner updates and chart
- keep entire chart history and label with channel/program
- mention Python syntax check results

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6847e46bc20483209bce42b1d99ae515