### PR TITLE
Improve polling control and program dropdown handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -454,7 +454,7 @@ def api_tune():
     # 3) Fetch streaminfo for subchannels. PSIP data may take a moment to
     # populate, so retry a few times before returning.
     subchannels = []
-    for _ in range(6):  # up to ~3s total
+    for _ in range(12):  # up to ~6s total
         streaminfo_raw = subprocess.getoutput(
             f"hdhomerun_config {device_id} get /tuner{tuner}/streaminfo"
         )


### PR DESCRIPTION
## Summary
- add `startPolling()` and `stopPolling()` helpers for cleaner pause/resume logic
- show a toast when no subchannels are returned from tuning
- wait up to 6 seconds for PSIP data in `/api/tune`

## Testing
- `python -m py_compile app.py`
- `node --check app-script.js`


------
https://chatgpt.com/codex/tasks/task_e_6847f045b2388320a8c9736fceeb91aa