### PR TITLE
Fix chart pause and add collapsible scan results

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # HDHomerunTuner
 
+**Version 1.0**
+
 A web-based manual tuner interface for SiliconDust HDHomeRun devices. The application is implemented in [Flask](https://flask.palletsprojects.com/) and includes a lightweight Bootstrap front end. It exposes several API endpoints for controlling tuners and viewing device status.
 
 ## Project Support
@@ -15,6 +17,8 @@ Ongoing maintenance and improvements are handled primarily through ChatGPT.
 - Retrieve bitrate information for a program
 - Clear tuner locks directly from the interface
 - View real-time signal quality using [Apache ECharts](https://echarts.apache.org)
+- Channel scan results collapse/expand under each physical channel
+- Real-time charts automatically pause while a channel scan is running
 
 ## API Endpoints
 

--- a/app-script.js
+++ b/app-script.js
@@ -93,6 +93,7 @@
   }
 
   // Toggle the "Scan Again" button into a spinner state
+  let scanningActive = false; // shared flag updated by setScanning()
   function setScanning(isScanning) {
     const btn = document.getElementById("scan-again-btn");
     if (!btn) return;
@@ -138,7 +139,6 @@
   document.addEventListener("DOMContentLoaded", () => {
     let selectedTuner = null;
     let pollingEnabled = true; // controls whether realtime points are added
-    let scanningActive = false; // true while channel scan is running
     let tunedChannel = null;
     let tunedProgram = null;
     let tunedProgramId = null;
@@ -493,10 +493,17 @@
       const tbody = document.getElementById("scan-table-body");
       tbody.innerHTML = "";
 
-      rows.forEach((ch) => {
+      rows.forEach((ch, idx) => {
         // ─── First Row: physical channel, SS cell, SNQ cell ───
         const row1 = document.createElement("tr");
         row1.classList.add("table-active");
+        row1.style.cursor = "pointer";
+
+        const collapseId = `collapse-${idx}`;
+        row1.setAttribute("data-bs-toggle", "collapse");
+        row1.setAttribute("data-bs-target", `#${collapseId}`);
+        row1.setAttribute("aria-expanded", "false");
+        row1.setAttribute("aria-controls", collapseId);
 
         // Column 1: physical channel #
         const th = document.createElement("th");
@@ -530,6 +537,8 @@
         // ─── Second Row: nested table of subchannels (if any) ───
         if (Array.isArray(ch.subchannels) && ch.subchannels.length > 0) {
           const row2 = document.createElement("tr");
+          row2.classList.add("collapse");
+          row2.id = collapseId;
           const tdNested = document.createElement("td");
           tdNested.colSpan = 4;
 


### PR DESCRIPTION
## Summary
- stop plotting during channel scans by correctly sharing the `scanningActive` flag
- make scan results collapsible on physical channel rows
- document version 1.0 and new features

## Testing
- `node --check app-script.js`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684895fcdc0483209337293623cb0527