### PR TITLE
Add export for channel scan results

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Ongoing maintenance and improvements are handled primarily through ChatGPT.
 - Channel scan results collapse/expand under each physical channel, with
   subchannels shown in an indented list
 - Real-time charts automatically pause while a channel scan is running
+- Export the latest channel scan results as labeled JSON for ChatGPT
 
 ## API Endpoints
 

--- a/index.html
+++ b/index.html
@@ -124,14 +124,24 @@
           <div class="card mb-4">
             <div class="card-header bg-warning-subtle d-flex w-100 justify-content-between align-items-center">
               <b>Channel Scan</b>
-              <button
-                id="scan-again-btn"
-                type="button"
-                class="btn btn-warning"
-                style="--bs-btn-padding-y: 0.15rem; --bs-btn-padding-x: 0.5rem; --bs-btn-font-size: 0.75rem;"
-              >
-                <i class="bi bi-tv-fill"></i> New Channel Scan
-              </button>
+              <div class="btn-group" role="group">
+                <button
+                  id="scan-again-btn"
+                  type="button"
+                  class="btn btn-warning"
+                  style="--bs-btn-padding-y: 0.15rem; --bs-btn-padding-x: 0.5rem; --bs-btn-font-size: 0.75rem;"
+                >
+                  <i class="bi bi-tv-fill"></i> New Channel Scan
+                </button>
+                <button
+                  id="export-scan-btn"
+                  type="button"
+                  class="btn btn-secondary"
+                  style="--bs-btn-padding-y: 0.15rem; --bs-btn-padding-x: 0.5rem; --bs-btn-font-size: 0.75rem;"
+                >
+                  <i class="bi bi-clipboard"></i> Export Results
+                </button>
+              </div>
             </div>
             <div class="card-body">
               <table class="table table-striped caption-top table-sm" id="scan-table">


### PR DESCRIPTION
## Summary
- add `Export Results` button in channel scan card
- implement clipboard export of last scan results in app-script.js
- track scan results in JavaScript and provide labeled JSON
- document new export feature in README

## Testing
- `node --check app-script.js`
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684921e60ac48320ada0e849d5028c96